### PR TITLE
"Fix: Resolve 'Trait not found' error by correcting HasBadge namespac…

### DIFF
--- a/src/Infolists/Components/SimpleListEntry.php
+++ b/src/Infolists/Components/SimpleListEntry.php
@@ -3,7 +3,7 @@
 namespace Thiktak\FilamentSimpleListEntry\Infolists\Components;
 
 use Closure;
-use Filament\Actions\Concerns\HasBadge;
+use Filament\Support\Concerns\HasBadge;
 use Filament\Infolists\Components\Entry;
 use Filament\Support\Concerns\HasExtraAttributes;
 use Thiktak\FilamentSimpleListEntry\Infolists\Traits;


### PR DESCRIPTION
### Pull Request: Namespace Correction for HasBadge Trait

#### Issue:
Encountered a 'Trait not found' error due to an incorrect namespace for the `HasBadge` trait within the `SimpleListEntry` component.

#### Resolution:
Updated the namespace for the `HasBadge` trait from `Filament\Actions\Concerns` to `Filament\Support\Concerns`. This change ensures proper trait resolution and compatibility, resolving the 'Trait not found' error and restoring functionality to the `SimpleListEntry` component.

#### Impact:
This fix enhances the stability and reliability of the `SimpleListEntry` component by ensuring that all traits are correctly referenced and loaded.
