### PR TITLE
adding support for open url in new tab

### DIFF
--- a/resources/views/infolists/components/simple-list-entry.blade.php
+++ b/resources/views/infolists/components/simple-list-entry.blade.php
@@ -4,51 +4,53 @@
         $inline = $getInline();
         $badge = null;
         $hasBadge = null;
-        
+        $shouldOpenUrlInNewTab = $shouldOpenUrlInNewTab();
+
         $isStyleInline = $getListStyle() == 'inline';
         $isStyleList = $getListStyle() == 'list';
-        
+
         if ($isStyleList) {
             $hasBadge = false;
             $separator = null;
-        
+
             $l1Class = 'divide-y divide-gray-200 overflow-hidden rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:divide-white/10 dark:bg-gray-900 dark:ring-white/10';
             $l2Class = 'flex items-center w-full p-3 gap-x-3 text-gray-700 outline-none transition duration-75 hover:bg-gray-100 focus:bg-gray-100 dark:text-gray-200 dark:hover:bg-white/5 dark:focus:bg-white/5';
         } else {
             $badge = $getBadge();
             $hasBadge = !empty($badge);
             $separator = $getSeparator();
-        
+
             $l1Class = 'flex flex-wrap items-center ' . ($hasBadge ? 'gap-1.5' : '');
             $l2Class = 'flex items-center ' . ($hasBadge ? '' : 'gap-0.5');
             $inline = false;
         }
-        
+
     @endphp
     <div data-l="1" class="{{ $l1Class }}">
         @forelse ($items as $itemKey => $itemElement)
             @php
                 $tagHref = $getItemUrl($itemElement);
                 $tag = $tagHref ? 'a' : 'div';
-                
+                $target = ($shouldOpenUrlInNewTab && $tagHref) ? 'target="_blank"' : '';
+
                 $tagAttributes = $attributes->merge(['class' => $l2Class])->merge($getItemExtraAttributes($itemElement), escape: false);
             @endphp
             <div data-l="2" {{ $tagAttributes }} class="{{ $inline ? 'inline-block' : 'block' }}">
 
                 @if ($hasBadge)
-                    <{{ $tag }} href="{{ $tagHref }}">
+                    <{{ $tag }} href="{{ $tagHref }}" {{ $target }}>
                         <x-filament::badge :color="$getBadgeColor()" :icon="$getItemIcon($itemElement)" :href="$tagHref">
                             {{ $getItemLabel($itemElement) }}
                         </x-filament::badge>
                         </{{ $tag }}>
                     @else
-                        <{{ $tag }} href="{{ $tagHref }}">
+                        <{{ $tag }} href="{{ $tagHref }}" {{ $target }}>
                             @if ($icon = $getItemIcon($itemElement))
                                 <x-filament::icon class="w-5 h-5 text-custom-600" :icon="$icon"
                                     style="{{ \Filament\Support\get_color_css_variables($getItemIconColor($itemElement), shades: [50, 300, 400, 500, 600]) }}" />
                             @endif
                             </{{ $tag }}>
-                            <{{ $tag }} href="{{ $tagHref }}" class="inline-block truncate">
+                            <{{ $tag }} href="{{ $tagHref }}" {{ $target }} class="inline-block truncate">
                                 {{ $getItemLabel($itemElement) }}
                                 <p class="text-xs text-gray-500">
                                     {{ $getItemDescription($itemElement) }}


### PR DESCRIPTION
Thank you @Thiktak for the plugin

I added support for opening urls in new tab
the trait `CanOpenUrl` already exist, so I only needed to add
`->openUrlInNewTab()` to my component

and I added `target="_blank"` in the `simple-list-entry.blade` file